### PR TITLE
use self.cfg.get to fetch (now configurable) configure/build/install commands in ConfigureMake and CMakeMake easyblocks

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -44,6 +44,9 @@ from easybuild.tools.run import run_cmd
 from vsc.utils.missing import nub
 
 
+DEFAULT_CONFIGURE_CMD = 'cmake'
+
+
 class CMakeMake(ConfigureMake):
     """Support for configuring build with CMake instead of traditional configure script"""
 
@@ -52,7 +55,7 @@ class CMakeMake(ConfigureMake):
         """Define extra easyconfig parameters specific to CMakeMake."""
         extra_vars = ConfigureMake.extra_options(extra_vars)
         extra_vars.update({
-            'configure_cmd': ['cmake', "Configure command to use", CUSTOM],
+            'configure_cmd': [DEFAULT_CONFIGURE_CMD, "Configure command to use", CUSTOM],
             'srcdir': [None, "Source directory location to provide to cmake command", CUSTOM],
             'separate_build_dir': [False, "Perform build in a separate directory", CUSTOM],
         })
@@ -113,7 +116,7 @@ class CMakeMake(ConfigureMake):
 
         command = ' '.join([
             self.cfg['preconfigopts'],
-            self.cfg['configure_cmd'],
+            self.cfg.get('configure_cmd', DEFAULT_CONFIGURE_CMD),
             options_string,
             self.cfg['configopts'],
             srcdir])


### PR DESCRIPTION
@mboisson for https://github.com/easybuilders/easybuild-easyblocks/pull/1628

For generic easyblocks that are commonly used as a base for others, we need to be a bit more careful w.r.t. grabbing values of custom easyconfig parameters, since they may not be defined in `self.cfg` when the easyblock that derives (indirectly) from `ConfigureMake` or `CMakeMake` may not correctly pick up on the custom easyconfigs parameters. 

I've also alphabetically reordered the entires in `ConfigureMake.extra_options`.

Both tested thoroughly by injecting dummy custom configure/build/install commands into easyconfigs...