### PR TITLE
Handle strange renaming inside the tarball/RPM distributed by Lumerical.

### DIFF
--- a/easybuild/easyblocks/l/lumerical.py
+++ b/easybuild/easyblocks/l/lumerical.py
@@ -47,9 +47,12 @@ class EB_Lumerical(PackedBinary):
         """
         super(EB_Lumerical, self).extract_step()
 
-        rpms = glob.glob(os.path.join(self.src[0]['finalpath'], 'rpm_install_files', 'Lumerical-%s*.rpm' % self.version))
+        rpms = glob.glob(os.path.join(self.src[0]['finalpath'], 'rpm_install_files', 'Lumerical-*.rpm'))
         if len(rpms) != 1:
             raise EasyBuildError("Incorrect number of RPMs found, was expecting exactly one: %s", rpms)
+
+        self.log.info("Found RPM: {}".format(rpms[0]))
+
         cmd = "rpm2cpio %s | cpio -idm " % rpms[0]
         run_cmd(cmd, log_all=True, simple=True)
 
@@ -67,6 +70,19 @@ class EB_Lumerical(PackedBinary):
         """Install Lumerical using copy tree."""
         mj_version = self.version.split('-')[0]
         fdtd_dir = os.path.join(self.cfg['start_dir'], 'opt', 'lumerical', mj_version)
+
+        if not os.path.isdir(fdtd_dir):
+            dirs = os.listdir(os.path.join(self.cfg['start_dir'], 'opt', 'lumerical'))
+            if len(dirs) != 1:
+                raise EasyBuildError("Install: can't determine source directory in {}".format(dirs))
+            mj_version = dirs[0]
+            # Is this sanity check necessary?
+            if mj_version[0] != 'v':
+                raise EasyBuildError("Install: directory {} does not start with a 'v'".format(mj_version))
+
+        fdtd_dir = os.path.join(self.cfg['start_dir'], 'opt', 'lumerical', mj_version)
+        self.log.info("Found install source directory: {}".format(fdtd_dir))
+
         copy_dir(fdtd_dir, self.installdir, symlinks=self.cfg['keepsymlinks'])
 
     def sanity_check_step(self):


### PR DESCRIPTION
This PR handles the following issues (while maintaining reverse compatibility):

* Unexpected name of RPM (e.g., `Lumerical-2021R1-2-dc09d2e.el6.x86_64.rpm` in tarball `Lumerical-2021-R1.2-2621-dc09d2e.tar.gz`)
* Unexpected base directory of install (e.g., `opt/lumerical/v221` instead of `opt/lumerical/2021R1` or such)

This PR doesn't handle the patch file though (pretty much have to hack a new patch each time).
To solve this, probably need to rework `apply_patch` method in the lumerical subclass:

 https://github.com/easybuilders/easybuild-framework/blob/ee83bb36ac0191d92ad58dbc391eb237c1cf855c/easybuild/framework/application.py#L574

(E.g., apply it in different directory with higher `-p` flag to `patch`)
