### PR TITLE
Expand GROMACS easyblock for CP2K QM/MM

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -68,6 +68,7 @@ class EB_GROMACS(CMakeMake):
             'mpiexec_numproc_flag': ['-np', "Flag to introduce the number of MPI tasks when running tests", CUSTOM],
             'mpi_numprocs': [0, "Number of MPI tasks to use when running tests", CUSTOM],
             'ignore_plumed_version_check': [False, "Ignore the version compatibility check for PLUMED", CUSTOM],
+            'with_plumed': ['auto', "Try to apply PLUMED patches ('auto', True or False)", CUSTOM],
         })
         extra_vars['separate_build_dir'][0] = True
         return extra_vars
@@ -211,6 +212,17 @@ class EB_GROMACS(CMakeMake):
 
         # check whether PLUMED is loaded as a dependency
         plumed_root = get_software_root('PLUMED')
+        if  str(self.cfg['with_plumed']).upper() == 'TRUE' :
+            if not plumed_root:
+                msg = "Compilation with PLUMED was expicitly selected, but PLUMED was not found."
+                raise EasyBuildError(msg)
+        elif str(self.cfg['with_plumed']).upper() == 'FALSE' :
+            if plumed_root:
+                self.log.info('PLUMED was found, but compilation without PLUMED has been requested.')
+            plumed_root = None
+        elif str(self.cfg['with_plumed']).upper() == 'AUTO':
+            pass
+
         if plumed_root:
             # Need to check if PLUMED has an engine for this version
             engine = 'gromacs-%s' % self.version

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -212,16 +212,17 @@ class EB_GROMACS(CMakeMake):
 
         # check whether PLUMED is loaded as a dependency
         plumed_root = get_software_root('PLUMED')
-        if  str(self.cfg['with_plumed']).upper() == 'TRUE' :
+        if str(self.cfg['with_plumed']).upper() == 'AUTO':
+            if plumed_root:
+                self.log.info('PLUMED has been auto-detected.')
+        elif self.cfg['with_plumed']:
             if not plumed_root:
                 msg = "Compilation with PLUMED was expicitly selected, but PLUMED was not found."
                 raise EasyBuildError(msg)
-        elif str(self.cfg['with_plumed']).upper() == 'FALSE' :
+        else:
             if plumed_root:
                 self.log.info('PLUMED was found, but compilation without PLUMED has been requested.')
             plumed_root = None
-        elif str(self.cfg['with_plumed']).upper() == 'AUTO':
-            pass
 
         if plumed_root:
             # Need to check if PLUMED has an engine for this version

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -68,7 +68,8 @@ class EB_GROMACS(CMakeMake):
             'mpiexec_numproc_flag': ['-np', "Flag to introduce the number of MPI tasks when running tests", CUSTOM],
             'mpi_numprocs': [0, "Number of MPI tasks to use when running tests", CUSTOM],
             'ignore_plumed_version_check': [False, "Ignore the version compatibility check for PLUMED", CUSTOM],
-            'with_plumed': ['auto', "Try to apply PLUMED patches ('auto', True or False)", CUSTOM],
+            'plumed': [None, "Try to apply PLUMED patches. None (default) is auto-detect. " +
+                       "True or False forces behaviour.", CUSTOM],
             'with_cp2k': ['auto', "Build with CP2K QM/MM  ('auto', True or False)", CUSTOM],
         })
         extra_vars['separate_build_dir'][0] = True
@@ -257,21 +258,20 @@ class EB_GROMACS(CMakeMake):
                 cp2k_linker_flags.append('-lint2')
             self.cfg.update('configopts', '-DCP2K_LINKER_FLAGS="%s"' % " ".join(cp2k_linker_flags))
 
-        # check whether PLUMED is loaded as a dependency
+        # PLUMED detection
         plumed_root = get_software_root('PLUMED')
-        if str(self.cfg['with_plumed']).upper() == 'AUTO':
-            if plumed_root:
-                self.log.info('PLUMED has been auto-detected.')
-        elif self.cfg['with_plumed']:
-            if not plumed_root:
-                msg = "Compilation with PLUMED was expicitly selected, but PLUMED was not found."
-                raise EasyBuildError(msg)
-        else:
-            if plumed_root:
-                self.log.info('PLUMED was found, but compilation without PLUMED has been requested.')
+        if self.cfg['plumed'] and not plumed_root:
+            msg = "The PLUMED module needs to be loaded to build GROMACS with PLUMED support."
+            raise EasyBuildError(msg)
+        elif plumed_root and self.cfg['plumed'] is False:
+            self.log.info('PLUMED was found, but compilation without PLUMED has been requested.')
             plumed_root = None
 
-        if plumed_root:
+        # enable PLUMED support if PLUMED is listed as a dependency
+        # and PLUMED support is either explicitly enabled (plumed = True) or unspecified ('plumed' not defined)
+        if plumed_root and (self.cfg['plumed'] or self.cfg['plumed'] is None):
+            self.log.info('PLUMED support has been enabled.')
+
             # Need to check if PLUMED has an engine for this version
             engine = 'gromacs-%s' % self.version
 

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -566,6 +566,12 @@ class EB_GROMACS(CMakeMake):
                         lib_subdir = os.path.dirname(libpaths[0])[len(self.installdir) + 1:]
                         self.log.info("Found lib subdirectory that contains %s: %s", libname, lib_subdir)
                         break
+                if not self.cfg['build_shared_libs']:
+                    msg = "Found lib subdirectory: %s but it doesn't contain: %s.\n"
+                    msg += "As building shared libs was disabled, this is probably okay."
+                    lib_subdir = libdir
+                    self.log.info(msg, lib_subdir, libname)
+
         if not lib_subdir:
             raise EasyBuildError("Failed to determine lib subdirectory in %s", self.installdir)
 
@@ -664,18 +670,22 @@ class EB_GROMACS(CMakeMake):
         ])
         bin_files.extend([b + suff for b in bins + mpi_bins for suff in suffixes])
 
-        if not self.lib_subdir:
-            self.lib_subdir = self.get_lib_subdir()
-
-        # pkgconfig dir not available for earlier versions, exact version to use here is unclear
-        if LooseVersion(self.version) >= LooseVersion('4.6'):
-            dirs.append(os.path.join(self.lib_subdir, 'pkgconfig'))
-
         custom_paths = {
-            'files': [os.path.join('bin', b) for b in bin_files] +
-            [os.path.join(self.lib_subdir, lib) for lib in lib_files],
-            'dirs': dirs,
+            'files': [os.path.join('bin', b) for b in bin_files],
+            'dirs': dirs
         }
+
+        if  self.cfg['build_shared_libs'] or LooseVersion(self.version) <= LooseVersion('2022'):
+            # only if any libs are actually built
+            if not self.lib_subdir:
+                self.lib_subdir = self.get_lib_subdir()
+
+            # pkgconfig dir not available for earlier versions, exact version to use here is unclear
+            if LooseVersion(self.version) >= LooseVersion('4.6'):
+                custom_paths['dirs'].append(os.path.join(self.lib_subdir, 'pkgconfig'))
+
+            custom_paths['files'] = custom_paths['files'] + [os.path.join(self.lib_subdir, lib) for lib in lib_files]
+
         super(EB_GROMACS, self).sanity_check_step(custom_paths=custom_paths)
 
     def run_all_steps(self, *args, **kwargs):

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -213,20 +213,21 @@ class EB_GROMACS(CMakeMake):
 
         # check whether CK2K is loaded as a dependency
         cp2k_root = get_software_root('CP2K')
-        if  str(self.cfg['with_cp2k']).upper() == 'TRUE' :
+        if str(self.cfg['with_cp2k']).upper() == 'AUTO':
+            if cp2k_root:
+                self.log.info('CP2K has been auto-detected.')
+        if self.cfg['with_cp2k']:
+            self.log.info("Building with CP2K was requested.")
             if not cp2k_root:
                 msg = "Compilation with CP2K was expicitly selected, but CP2K was not found."
                 raise EasyBuildError(msg)
-            self.log.info("Building with CP2K was requested.")
-        elif str(self.cfg['with_cp2k']).upper() == 'FALSE' :
+        else:
             if cp2k_root:
                 self.log.info('CP2K was found, but compilation without CP2K has been requested.')
             cp2k_root = None
-        elif str(self.cfg['with_cp2k']).upper() == 'AUTO' and cp2k_root:
-            self.log.info('CP2K has been auto-detected.')
 
         if LooseVersion(self.version) < LooseVersion('2022') and cp2k_root:
-            msg ='CP2K support is only available for GROMACS 2022 and newer.'
+            msg = 'CP2K support is only available for GROMACS 2022 and newer.'
             raise EasyBuildError(msg)
         elif cp2k_root and LooseVersion(get_software_version('CP2K')) < LooseVersion('8.1'):
             msg = 'CP2K support in GROMACS requires CP2K version 8.1 or higher.'

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -675,7 +675,7 @@ class EB_GROMACS(CMakeMake):
             'dirs': dirs
         }
 
-        if  self.cfg['build_shared_libs'] or LooseVersion(self.version) <= LooseVersion('2022'):
+        if self.cfg['build_shared_libs'] or LooseVersion(self.version) <= LooseVersion('2022'):
             # only if any libs are actually built
             if not self.lib_subdir:
                 self.lib_subdir = self.get_lib_subdir()


### PR DESCRIPTION
This PR implements building GROMACS with CP2K QM/MM enabled.

In order to do so, two other aspects had to be resolved:
- being able to override PLUMED auto-detection (in case CP2K was compiled with a version of PLUMED that does not support the GROMACS version used).
- make sanity-check work with a statically built GROMACS (which is lacking the libs)


I've split these aspects into separate commits, so that they can be reviewed more easily.
