### PR TITLE
Update namd.py to still support NAMD 2.14 build

### DIFF
--- a/easybuild/easyblocks/n/namd.py
+++ b/easybuild/easyblocks/n/namd.py
@@ -158,7 +158,11 @@ class EB_NAMD(MakeCp):
         cxxflags = os.environ['CXXFLAGS']
         if LooseVersion(self.version) >= LooseVersion('2.12'):
             cxxflags += ' --std=c++11'
-        self.cfg.update('namd_cfg_opts', '--cxx "%s" --cxx-opts "%s"' % (os.environ['CXX'], cxxflags))
+
+        if comp_fam == "Intel" :
+            self.cfg.update('namd_cfg_opts', '--cxx "%s" --cxx-opts "%s" --cxx-noalias-opts "%s -fno-alias"' % (os.environ['CXX'], cxxflags, cxxflags))
+        else:
+            self.cfg.update('namd_cfg_opts', '--cxx "%s" --cxx-opts "%s"' % (os.environ['CXX'], cxxflags))
 
         # NAMD dependencies: CUDA, TCL, FFTW
         cuda = get_software_root('CUDA')


### PR DESCRIPTION
The -fno-alias is needed by icc build of NAMD 2.14 but should not be used by other compilers.